### PR TITLE
Add windows-curses dependency for Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 certifi==2018.8.24
 python-dateutil==2.8.1
 six==1.14.0
+windows-curses==2.2.0; sys_platform == 'win32'


### PR DESCRIPTION
Running the tool on Windows fails with:

```
Traceback (most recent call last):
  File ".\aaa.py", line 16, in <module>
    from controls import *
  File "C:\Daten\ArangoDB\aaa\controls.py", line 1, in <module>
    import curses, curses.ascii
  File "C:\Python37\lib\curses\__init__.py", line 13, in <module>
    from _curses import *
ModuleNotFoundError: No module named '_curses'
```

It works after installing the `windows-curses` package.

This PR adds the package to `requirements.txt` for Windows. On Linux, running `pip install -r requirements.txt` will skip it with this message:

```
Ignoring windows-curses: markers 'sys_platform == "win32"' don't match your environment
```