### PR TITLE
Windows support

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ again name is optional and if empty a prompt with autocomplete will open.
 You can use `0-9` keys as shortcuts to restore state `"0"-"9"`. To save the state
 use `ALT + "x"`.
 
+### Live mode
+
+You can make _aaa_ wait for a cluster to become available, then start following the agency live. 
+This is particularly useful during integration tests.  
+Before starting a test suite, run:  
+`python aaa.py --follow --live $(python wait-for-agency.py)` 
+
 # Annotations Format
 
 You can modify the annotations format. There are currently three topics:

--- a/aaa.py
+++ b/aaa.py
@@ -432,7 +432,7 @@ class AgencyLogList(Control):
 
     def execute_highlight_command(self, cmd: HighlightCommand):
         if cmd.save or cmd.clear:
-            raise RuntimeException("save and clear not yet implemented")
+            raise RuntimeError("save and clear not yet implemented")
 
         if cmd.expr is None:
             # delete that highlight

--- a/controls.py
+++ b/controls.py
@@ -500,11 +500,20 @@ class App:
         curses.update_lines_cols()
         self.layout()
 
+    def wait_for_stdin(self):
+        import platform
+        if platform.system() == "Windows":
+            import win32file, win32event, win32api
+            win32file.FlushFileBuffers(win32api.STD_INPUT_HANDLE)
+            win32event.WaitForSingleObject(win32api.STD_INPUT_HANDLE, win32event.INFINITE)
+        else:
+            import select, sys
+            select.select([sys.stdin], [], [])
+
     def read_input(self):
         try:
-            import select, sys
             while not self.stop:
-                select.select([sys.stdin], [], [])
+                self.wait_for_stdin()
                 self.wait_event.clear()
                 self.input_queue.put(InputEvent(0))
                 self.wait_event.wait()

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ certifi==2018.8.24
 python-dateutil==2.8.1
 six==1.14.0
 windows-curses==2.2.0; sys_platform == 'win32'
+pywin32==304; sys_platform == 'win32'

--- a/wait-for-agency.py
+++ b/wait-for-agency.py
@@ -23,7 +23,7 @@ def wait_for_agency_endpoint():
 
         for pid in new:
             p = psutil.Process(pid)
-            if p.name() == "arangod":
+            if p.name() == "arangod" or p.name() == "arangod.exe":
                 cmdline = p.cmdline()
                 if get_cmdline_value(cmdline, "--agency.activate") == "true":
                     return get_cmdline_value(cmdline, "--agency.my-address")
@@ -35,7 +35,7 @@ def wait_for_leader(endpoint):
             response = requests.get(f"{endpoint}/_api/agency/config")
             if response.status_code == 200:
                 config = response.json()
-                if 'leaderId' in config:
+                if config.get('leaderId'):
                     return config['configuration']['pool'][config['leaderId']]
                 else:
                     print("leader not yet available", file=sys.stderr)
@@ -68,4 +68,4 @@ def main():
 
 
 if __name__ == "__main__":
-    main(*sys.argv[1:])
+    main()


### PR DESCRIPTION
This PR adds native Windows support, so one can use _aaa_ from any cmd or powershell.
The problem was that waiting for input with `select` is not fully compatible with Windows. Here's a snippet from their documentation:
```
On Windows, only sockets are supported; on Unix, all file descriptors.
```
Unfortunately, after experimenting with that, the only thing that works for me is to use `pywin32`.

Additional changes:
- fixed error reporting in live mode (no more _exception: ''_)
- updated documentation

I tested the changes on Windows and Linux.