### PR TITLE
Use utf8 when loading agency dumps

### DIFF
--- a/aaa.py
+++ b/aaa.py
@@ -1216,7 +1216,7 @@ class ArangoAgencyLogFileProvider:
         log = None
         snapshot = None
 
-        with open(self.logfile) as f:
+        with open(self.logfile, "r", encoding="utf-8") as f:
             print("Loading log from `{}`".format(self.logfile))
             log = json.load(f)
             if isinstance(log, dict):
@@ -1236,7 +1236,7 @@ class ArangoAgencyLogFileProvider:
 
         if self.snapshotFile:
             if snapshot == None:
-                with open(self.snapshotFile) as f:
+                with open(self.snapshotFile, "r", encoding="utf-8") as f:
                     print("Loading snapshot from `{}`".format(self.snapshotFile))
                     snapshot = json.load(f)
             else:


### PR DESCRIPTION
There are tests which generate database names that contain unicode characters, see [this file](https://github.com/arangodb/arangodb/blob/devel/tests/js/client/load-balancing/load-balancing-cursor-noauth-cluster.js#L37) for example. If such a test exists in a suite,  _aaa_ unfortunately crashes when we try to load the agency dump.